### PR TITLE
POM: Stop using git:// protocol with github.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 	</repositories>
 
 	<scm>
-		<connection>scm:git:git://github.com/juglab/labkit-ui</connection>
+		<connection>scm:git:https://github.com/juglab/labkit-ui</connection>
 		<developerConnection>scm:git:git@github.com:juglab/labkit-ui</developerConnection>
 		<tag>HEAD</tag>
 		<url>https://github.com/juglab/labkit-ui</url>


### PR DESCRIPTION
The GitHub platform is discontinuing support for it.

See: https://github.blog/2021-09-01-improving-git-protocol-security-github/#whats-changing