### PR TITLE
Batch speed optimization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,8 @@
 
 		<jackson-dataformat-yaml.version>2.11.1</jackson-dataformat-yaml.version>
 
-		<labkit-pixel-classification.version>0.1.13</labkit-pixel-classification.version>
+		<imglib2-algorithm.version>0.12.1</imglib2-algorithm.version>
+		<labkit-pixel-classification.version>0.1.14</labkit-pixel-classification.version>
 	</properties>
 
 	<build>
@@ -119,6 +120,11 @@
 	</build>
 
 	<dependencies>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm</artifactId>
+			<version>${imglib2-algorithm.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>

--- a/src/main/java/sc/fiji/labkit/ui/BatchSegmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/BatchSegmenter.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * The Labkit image segmentation tool for Fiji.
+ * %%
+ * Copyright (C) 2017 - 2022 Matthias Arzt
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package sc.fiji.labkit.ui;
+
+import ij.ImagePlus;
+import io.scif.img.ImgSaver;
+import net.imagej.ImgPlus;
+import net.imglib2.img.VirtualStackAdapter;
+import sc.fiji.labkit.ui.segmentation.Segmenter;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import bdv.export.ProgressWriter;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+
+import java.io.File;
+
+/**
+ * @deprecated Use {@link sc.fiji.labkit.ui.segmentation.SegmentationTool}
+ *             instead.
+ *             <p>
+ *             Helper class for segmenting multiple image files.
+ * @author Matthias Arzt
+ */
+@Deprecated
+public class BatchSegmenter {
+
+	private final ImgSaver saver = new ImgSaver();
+	private final Segmenter segmenter;
+	private final ProgressWriter progressWriter;
+
+	public BatchSegmenter(Segmenter segmenter, ProgressWriter progressWriter) {
+		this.segmenter = segmenter;
+		this.progressWriter = progressWriter;
+	}
+
+	public void segment(File inputFile, File outputFile) {
+		ImgPlus<?> img = VirtualStackAdapter.wrap(new ImagePlus(inputFile.getAbsolutePath()));
+		Img<UnsignedByteType> result = ArrayImgs.unsignedBytes(Intervals.dimensionsAsLongArray(img));
+		segmenter.segment(img, result);
+		saver.saveImg(outputFile.getAbsolutePath(), result);
+	}
+
+}

--- a/src/test/java/sc/fiji/labkit/ui/segmentation/BatchBenchmark.java
+++ b/src/test/java/sc/fiji/labkit/ui/segmentation/BatchBenchmark.java
@@ -1,0 +1,89 @@
+
+package sc.fiji.labkit.ui.segmentation;
+
+import bdv.export.ProgressWriterConsole;
+import net.imglib2.util.StopWatch;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.scijava.Context;
+import org.scijava.command.CommandService;
+import sc.fiji.labkit.pixel_classification.utils.SingletonContext;
+import sc.fiji.labkit.ui.BatchSegmenter;
+import sc.fiji.labkit.ui.plugin.LabkitSegmentImagesInDirectoryPlugin;
+import sc.fiji.labkit.ui.segmentation.weka.TrainableSegmentationSegmenter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.concurrent.ExecutionException;
+
+public class BatchBenchmark {
+
+	private static final String base = "/home/arzt/tmp/labkit-memory-test/";
+
+	private static final String inputDirectory = base + "input/";
+
+	private static final String segmenterFile = base + "normal.classifier";
+
+	private static final String outputDirectory = base + "output/";
+
+	private static final String fileFilter = "Untitled_1*.tif";
+
+	private static final boolean useGpu = false;
+
+	public static void main(String... args) throws Exception {
+		runNewVersion();
+	}
+
+	private static void runOldVersion() throws Exception {
+		Context context = SingletonContext.getInstance();
+		StopWatch sw = StopWatch.createAndStart();
+		TrainableSegmentationSegmenter segmenter = new TrainableSegmentationSegmenter(context);
+		segmenter.setUseGpu(useGpu);
+		segmenter.openModel(segmenterFile);
+		BatchSegmenter batch = new BatchSegmenter(segmenter, new ProgressWriterConsole());
+		for (File input : listFiles()) {
+			System.out.println(input);
+			batch.segment(input, new File(outputDirectory, input.getName()));
+		}
+		System.out.println(sw);
+		context.close();
+		System.exit(0);
+	}
+
+	private static File[] listFiles() {
+		File baseFile = new File(inputDirectory);
+		File[] files = baseFile.listFiles((FileFilter) new WildcardFileFilter(fileFilter));
+		if (files != null)
+			return files;
+		return new File[0];
+	}
+
+	private static void runNewVersion()
+		throws InterruptedException, ExecutionException
+	{
+		Context context = SingletonContext.getInstance();
+		CommandService cmd = context.service(CommandService.class);
+		System.out.println("start");
+		removeImageFromDirectory(outputDirectory);
+		StopWatch stopWatch = StopWatch.createAndStart();
+		cmd.run(LabkitSegmentImagesInDirectoryPlugin.class, true,
+			"input_directory", inputDirectory,
+			"file_filter", fileFilter,
+			"output_directory", outputDirectory,
+			"output_file_suffix", "segmentation.tif",
+			"segmenter_file", segmenterFile,
+			"use_gpu", useGpu).get();
+		System.out.println("stop");
+		System.out.println(stopWatch);
+		System.exit(0);
+	}
+
+	private static void removeImageFromDirectory(String directory) {
+		File d = new File(directory);
+		FileFilter fileFilter = new WildcardFileFilter("*.tif");
+		File[] files = d.listFiles(fileFilter);
+		if (files == null)
+			return;
+		for (File file : files)
+			file.delete();
+	}
+}


### PR DESCRIPTION
The way Labkit uses resources to batch process images can still be improved:
* process small images in parallel
* set optimal TaskExecutors for CPU and GPU processing
* match the number of parallel GPU accesses to the available GPU memory
* allow to increase the block size

The PR adds a BatchBenchmark that allows to measure Labkits performance when operating on multiple images, and also has some WIP code for setting TaskExecutors.