### PR TITLE
Update the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
 			<name>Tobias Pietzsch</name>
 			<url>https://imagej.net/people/tpietzsch</url>
 		</contributor>
-        <contributor>
+		<contributor>
 			<name>Deborah Schmidt</name>
 			<url>https://imagej.net/people/frauzufall</url>
 		</contributor>
 		<contributor>
 			<name>Philipp Hanslovsky</name>
-            <url>https://imagej.net/people/hanslovsky</url>
+			<url>https://imagej.net/people/hanslovsky</url>
 		</contributor>
 	</contributors>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<inceptionYear>2017</inceptionYear>
 	<organization>
 		<name>CSBD</name>
-		<url>http://csbdresden.de/</url>
+		<url>https://www.csbdresden.de/</url>
 	</organization>
 	<licenses>
 		<license>
@@ -38,7 +38,7 @@
 		<developer>
 			<id>maarzt</id>
 			<name>Matthias Arzt</name>
-			<url>https://imagej.net/people/Maarzt</url>
+			<url>https://imagej.net/people/maarzt</url>
 			<roles>
 				<role>lead</role>
 				<role>developer</role>

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,9 @@
 		<package-name>sc.fiji.labkit.ui</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Matthias Arzt</license.copyrightOwners>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-
-		<jackson-dataformat-yaml.version>2.11.1</jackson-dataformat-yaml.version>
-
-		<labkit-pixel-classification.version>0.1.15</labkit-pixel-classification.version>
 	</properties>
 
 	<build>
@@ -207,7 +204,6 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>labkit-pixel-classification</artifactId>
-			<version>${labkit-pixel-classification.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
@@ -246,7 +242,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>${jackson-dataformat-yaml.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,6 @@
 		</license>
 	</licenses>
 
-	<mailingLists>
-		<mailingList>
-			<name>Image.sc Forum</name>
-			<archive>https://forum.image.sc/tags/labkit</archive>
-		</mailingList>
-	</mailingLists>
-
 	<developers>
 		<developer>
 			<id>maarzt</id>
@@ -65,12 +58,12 @@
 		</contributor>
 	</contributors>
 
-	<repositories>
-		<repository>
-			<id>scijava.public</id>
-			<url>https://maven.scijava.org/content/groups/public</url>
-		</repository>
-	</repositories>
+	<mailingLists>
+		<mailingList>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/labkit</archive>
+		</mailingList>
+	</mailingLists>
 
 	<scm>
 		<connection>scm:git:https://github.com/juglab/labkit-ui</connection>
@@ -95,21 +88,6 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>net.revelc.code.formatter</groupId>
-					<artifactId>formatter-maven-plugin</artifactId>
-					<version>${formatter-maven-plugin.version}</version>
-					<configuration>
-						<configFile>coding-style.xml</configFile>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
 
 	<dependencies>
 		<dependency>
@@ -286,4 +264,26 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>net.revelc.code.formatter</groupId>
+					<artifactId>formatter-maven-plugin</artifactId>
+					<version>${formatter-maven-plugin.version}</version>
+					<configuration>
+						<configFile>coding-style.xml</configFile>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,6 @@
 		</developer>
 	</developers>
 	<contributors>
-		<!--
-		NB: Need at least one element to override the parent.
-		See: https://issues.apache.org/jira/browse/MNG-5220
-		-->
 		<contributor>
 			<name>Tobias Pietzsch</name>
 			<url>https://imagej.net/people/tpietzsch</url>


### PR DESCRIPTION
This patch set corrects several minor POM issues.

It also updates the parent to the latest release (32.0.0), which fixes a dependency issue where xml-apis is excluded and creates a runtime problem with Java 8 (`java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal`).
