### PR TITLE
LabelPanel: faster removeAllLabels

### DIFF
--- a/src/main/java/sc/fiji/labkit/ui/models/ColoredLabelsModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/ColoredLabelsModel.java
@@ -92,6 +92,11 @@ public class ColoredLabelsModel {
 		fireLabelsChanged();
 	}
 
+	public void removeAllLabels(List<Label> items) {
+		items.forEach(label -> model.labeling().get().removeLabel(label));
+		fireLabelsChanged();
+	}
+
 	public void removeLabel(Label label) {
 		model.labeling().get().removeLabel(label);
 		fireLabelsChanged();

--- a/src/main/java/sc/fiji/labkit/ui/panel/LabelPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/LabelPanel.java
@@ -138,7 +138,7 @@ public class LabelPanel {
 
 	private void removeAllLabels() {
 		List<Label> items = new ArrayList<>(model.items());
-		items.forEach(model::removeLabel);
+		model.removeAllLabels(items);
 	}
 
 	private void renameLabel(Label label) {


### PR DESCRIPTION
Hi,

`removeAllLabels()` in LabelPanel is very slow when called on larger amounts of labels. This is due to `fireLabelsChanged()` being called after every item.
This small change speeds up the deletion and increases stability.