### PR TITLE
Calculate probability adapted for headless mode

### DIFF
--- a/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
@@ -29,13 +29,8 @@
 
 package sc.fiji.labkit.ui.plugin;
 
-import bdv.export.ProgressWriterConsole;
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
-import net.imagej.ImgPlus;
-import net.imglib2.img.Img;
-import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Intervals;
 import org.scijava.Cancelable;
 import org.scijava.Context;
 import org.scijava.ItemIO;
@@ -43,12 +38,7 @@ import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import sc.fiji.labkit.ui.inputimage.DatasetInputImage;
 import sc.fiji.labkit.ui.segmentation.SegmentationTool;
-import sc.fiji.labkit.ui.segmentation.SegmentationUtils;
-import sc.fiji.labkit.ui.segmentation.Segmenter;
-import sc.fiji.labkit.ui.segmentation.weka.TrainableSegmentationSegmenter;
-import sc.fiji.labkit.ui.utils.ParallelUtils;
 import sc.fiji.labkit.ui.utils.progress.StatusServiceProgressWriter;
 
 import java.io.File;

--- a/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
@@ -29,8 +29,11 @@
 
 package sc.fiji.labkit.ui.plugin;
 
+import ij.ImagePlus;
 import net.imagej.Dataset;
-import net.imagej.DatasetService;
+import net.imagej.ImgPlus;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.real.FloatType;
 import org.scijava.Cancelable;
 import org.scijava.Context;
 import org.scijava.ItemIO;
@@ -55,9 +58,6 @@ public class CalculateProbabilityMapWithLabkitPlugin implements Command, Cancela
 	private Context context;
 
 	@Parameter
-	private DatasetService datasetService;
-
-	@Parameter
 	private StatusService statusService;
 
 	@Parameter
@@ -67,7 +67,7 @@ public class CalculateProbabilityMapWithLabkitPlugin implements Command, Cancela
 	private File segmenter_file;
 
 	@Parameter(type = ItemIO.OUTPUT)
-	private Dataset output;
+	private ImagePlus output_ij1;
 
 	@Parameter(required = false)
 	private Boolean use_gpu = false;
@@ -79,7 +79,10 @@ public class CalculateProbabilityMapWithLabkitPlugin implements Command, Cancela
 		segmenter.openModel(segmenter_file.getAbsolutePath());
 		segmenter.setUseGpu(use_gpu);
 		segmenter.setProgressWriter(new StatusServiceProgressWriter(statusService));
-		output = datasetService.create(segmenter.probabilityMap(input.getImgPlus()));
+		final ImgPlus<FloatType> baselineImage = segmenter.probabilityMap(input.getImgPlus());
+		output_ij1 = ImageJFunctions.wrap(baselineImage, baselineImage.getName());
+		output_ij1.show();
+		//NB: this makes the created image accessible even in the headless mode of ImageJ
 	}
 
 	@Override


### PR DESCRIPTION
Hi @maarzt ,

considering the following code snippet from a larger .IJM script
```javascript
//runs the classifier, creates a new image window and selects/activates it
run("Calculate Probability Map With Labkit", "input="+inputImageWindowTitle+" segmenter_file="+classifierFile+" use_gpu="+use_gpu);
selectWindow("probability map for "+inputImageWindowTitle);

//remove the 2nd channel/class
setSlice(2);
run("Delete Slice");

//segment the 1st channel/class
setThreshold(0.3, 2.0);
setOption("BlackBackground", false);
run("Convert to Mask");
```

This could be used in a loop over several files:
```
for (tp = 297; tp <= 420; tp+=2) {
	process_one_timepoint(tp, classifierFile);
}
```
Notice the looping can be arbitrary. Here, for example, it is cherry-picking every second image. This is only to say that I prefer to do the looping on my own, in contrast to running the "labkit over a folder with files" menu item.

Back to the snipper, if you run this from a normal Fiji, that is with GUI window from macro editor, all works well. When you run this from command line, e.g. `./ImageJ-linux64 --headless  --run ~/somePath/labkit_pipeline.ijm` it breaks on the `selectWindow()` command. Despite an output Dataset is created, IJM macros cannot reach the product of Labkit (at least I failed figuring out). For example, dropping the `selectWindow()` command makes the script (the `setSlice()`) operate on the `inputImageWindow` which was "opened" and visible while the product of Labkit is existing somewhere inside but is not reachable. What has helped me out was to make Labkit create IJ1 image and return it, which is precisely the content in this PR.
Needless to say, the snippet works well *also* from headless mode when this PR is applied.

I'm not excited to be using IJ1 data structures. But I couldn't figure out how to reach the "internal `DatasetView`" from IJM, and actually, I'm not sure how Jython's ability to talk to underlying Java could help here. Maybe this IJ1 version should be a new command on its own?

And also, the same "patch" we should apply to the sibling "nonGUI Labkit segmentation" plugin.