### PR TITLE
Update to ImgLib2 6.x API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,17 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
+		<imagej-deprecated.version>0.2.0</imagej-deprecated.version>
+		<imagej-ops.version>2.0.0</imagej-ops.version>
+		<imglib2.version>6.1.0</imglib2.version>
+		<imglib2-algorithm.version>0.13.2</imglib2-algorithm.version>
+		<imglib2-algorithm-gpl.version>0.3.1</imglib2-algorithm-gpl.version>
+		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
+		<imglib2-realtransform.version>4.0.1</imglib2-realtransform.version>
+		<imglib2-roi.version>0.14.0</imglib2-roi.version>
+		<scifio.version>0.45.0</scifio.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>33.2.0</version>
+		<version>34.1.0</version>
 	</parent>
 
 	<groupId>sc.fiji</groupId>
@@ -85,6 +85,11 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Matthias Arzt</license.copyrightOwners>
 
+		<imglib2.version>6.1.0</imglib2.version>
+		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
+		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-32</bigdataviewer-vistools.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>
@@ -157,7 +162,6 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-algorithm</artifactId>
-			<version>${imglib2-algorithm.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
@@ -32,7 +32,6 @@ package sc.fiji.labkit.ui.brush.neighborhood;
 import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
-import net.imglib2.Sampler;
 
 public final class MappingCursor<T> extends AbstractEuclideanSpace implements
 	Cursor<T>
@@ -147,12 +146,7 @@ public final class MappingCursor<T> extends AbstractEuclideanSpace implements
 	}
 
 	@Override
-	public Sampler<T> copy() {
-		return source.copy();
-	}
-
-	@Override
-	public MappingCursor<T> copyCursor() {
+	public MappingCursor<T> copy() {
 		return new MappingCursor<>(this);
 	}
 }

--- a/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
@@ -54,8 +54,8 @@ public final class MappingCursor<T> extends AbstractEuclideanSpace implements
 	}
 
 	public MappingCursor(MappingCursor<T> mappingCursor) {
-		this(mappingCursor.offset, mappingCursor.cursor.copyCursor(),
-			mappingCursor.source.copyRandomAccess());
+		this(mappingCursor.offset, mappingCursor.cursor.copy(),
+			mappingCursor.source.copy());
 	}
 
 	@Override

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
@@ -47,7 +47,7 @@ public class MappingCursor<T> implements Cursor<T> {
 	}
 
 	@Override
-	public Cursor<T> copy() {
+	public MappingCursor<T> copy() {
 		return new MappingCursor<>(cursor.copyCursor(), randomAccess
 			.copy());
 	}

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
@@ -31,7 +31,6 @@ package sc.fiji.labkit.ui.utils.sparse;
 
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
-import net.imglib2.Sampler;
 
 /**
  * @author Matthias Arzt
@@ -48,9 +47,9 @@ public class MappingCursor<T> implements Cursor<T> {
 	}
 
 	@Override
-	public Cursor<T> copyCursor() {
+	public Cursor<T> copy() {
 		return new MappingCursor<>(cursor.copyCursor(), randomAccess
-			.copyRandomAccess());
+			.copy());
 	}
 
 	@Override
@@ -130,10 +129,5 @@ public class MappingCursor<T> implements Cursor<T> {
 	@Override
 	public T get() {
 		return randomAccess.get();
-	}
-
-	@Override
-	public Sampler<T> copy() {
-		return randomAccess.copy();
 	}
 }

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
@@ -142,12 +142,7 @@ public class SparseIterableRegion extends AbstractWrappedInterval<Interval>
 		}
 
 		@Override
-		public AbstractCursor<Void> copy() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public AbstractCursor<Void> copyCursor() {
+		public SparseRoiCursor copy() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
@@ -38,7 +38,6 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
-import net.imglib2.Sampler;
 import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.type.logic.BitType;
@@ -206,18 +205,13 @@ public class SparseIterableRegion extends AbstractWrappedInterval<Interval>
 		}
 
 		@Override
-		public RandomAccess<BitType> copyRandomAccess() {
+		public RandomAccess<BitType> copy() {
 			return new SparseRoiRandomAccess(this);
 		}
 
 		@Override
 		public BitType get() {
 			return value;
-		}
-
-		@Override
-		public Sampler<BitType> copy() {
-			throw new UnsupportedOperationException();
 		}
 	}
 }

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntType.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntType.java
@@ -38,7 +38,6 @@ import net.imglib2.Localizable;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.Sampler;
 import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.type.BooleanType;
@@ -151,18 +150,13 @@ public class SparseRandomAccessIntType extends AbstractWrappedInterval<Interval>
 		}
 
 		@Override
-		public RandomAccess<IntType> copyRandomAccess() {
+		public RandomAccess<IntType> copy() {
 			return new MyRandomAccess(this);
 		}
 
 		@Override
 		public IntType get() {
 			return value;
-		}
-
-		@Override
-		public Sampler<IntType> copy() {
-			throw new UnsupportedOperationException();
 		}
 	}
 }


### PR DESCRIPTION
This work updates the POM to depend on imglib2-6.x-based component versions, and makes the necessary changes to the code to account for the associated API breakages.

It would be nice to merge and release this work ASAP as a new version of labkit-ui, so that we can get it into pom-scijava 35 (and also hopefully start bundling Labkit with Fiji, finally!).
