### PR TITLE
Eliminate imagej-legacy dependency

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 - 2023, Matthias Arzt
+Copyright (c) 2017 - 2024, Matthias Arzt
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pom.xml
+++ b/pom.xml
@@ -175,10 +175,6 @@
 			<artifactId>imglib2-algorithm</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-legacy</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 		</dependency>

--- a/src/main/java/sc/fiji/labkit/ui/ActionsAndBehaviours.java
+++ b/src/main/java/sc/fiji/labkit/ui/ActionsAndBehaviours.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/BasicLabelingComponent.java
+++ b/src/main/java/sc/fiji/labkit/ui/BasicLabelingComponent.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/BatchSegmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/BatchSegmenter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/DefaultExtensible.java
+++ b/src/main/java/sc/fiji/labkit/ui/DefaultExtensible.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/Extensible.java
+++ b/src/main/java/sc/fiji/labkit/ui/Extensible.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/InitialLabeling.java
+++ b/src/main/java/sc/fiji/labkit/ui/InitialLabeling.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/LabelingComponent.java
+++ b/src/main/java/sc/fiji/labkit/ui/LabelingComponent.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/LabkitFrame.java
+++ b/src/main/java/sc/fiji/labkit/ui/LabkitFrame.java
@@ -31,7 +31,6 @@ package sc.fiji.labkit.ui;
 
 import io.scif.services.DatasetIOService;
 import net.imagej.Dataset;
-import net.imagej.legacy.ui.LegacyApplicationFrame;
 import org.scijava.ui.ApplicationFrame;
 import org.scijava.ui.UIService;
 import org.scijava.widget.UIComponent;
@@ -113,11 +112,14 @@ public class LabkitFrame {
 			// NB: get ImageJ icon form the main UI window
 			UIService uiService = context.service(UIService.class);
 			ApplicationFrame applicationFrame = uiService.getDefaultUI().getApplicationFrame();
-			if (applicationFrame instanceof LegacyApplicationFrame)
-				return ((LegacyApplicationFrame) applicationFrame).getComponent().getIconImage();
+			Frame frame = null;
 			if (applicationFrame instanceof Frame)
-				return ((Frame) applicationFrame).getIconImage();
-			return null;
+				frame = (Frame) applicationFrame;
+			else if (applicationFrame instanceof UIComponent) {
+				Object uic = ((UIComponent) applicationFrame).getComponent();
+				if (uic instanceof Frame) frame = (Frame) uic;
+			}
+			return frame == null ? null : frame.getIconImage();
 		}
 		catch (Exception e) {
 			return null;

--- a/src/main/java/sc/fiji/labkit/ui/LabkitFrame.java
+++ b/src/main/java/sc/fiji/labkit/ui/LabkitFrame.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/Main.java
+++ b/src/main/java/sc/fiji/labkit/ui/Main.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/MenuBar.java
+++ b/src/main/java/sc/fiji/labkit/ui/MenuBar.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/Preferences.java
+++ b/src/main/java/sc/fiji/labkit/ui/Preferences.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/SegmentationComponent.java
+++ b/src/main/java/sc/fiji/labkit/ui/SegmentationComponent.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/AbstractFileIoAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/AbstractFileIoAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/AddLabelingIoAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/AddLabelingIoAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/BatchSegmentAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/BatchSegmentAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/BitmapImportExportAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/BitmapImportExportAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/ClassifierIoAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/ClassifierIoAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/ClassifierSettingsAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/ClassifierSettingsAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/LabelEditAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/LabelEditAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/LabelingIoAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/LabelingIoAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/ResetViewAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/ResetViewAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/SegmentationAsLabelAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/SegmentationAsLabelAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/SegmentationExportAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/SegmentationExportAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/SetLabelsAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/SetLabelsAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/actions/ShowHelpAction.java
+++ b/src/main/java/sc/fiji/labkit/ui/actions/ShowHelpAction.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/BdvAutoContrast.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/BdvAutoContrast.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/BdvLayer.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/BdvLayer.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/BdvLayerLink.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/BdvLayerLink.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/BdvShowable.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/BdvShowable.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/ImgPlusBdvShowable.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/ImgPlusBdvShowable.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/SimpleBdvShowable.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/SimpleBdvShowable.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/SourceBdvShowable.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/SourceBdvShowable.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/bdv/SpimBdvShowable.java
+++ b/src/main/java/sc/fiji/labkit/ui/bdv/SpimBdvShowable.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/BdvMouseBehaviourUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/BdvMouseBehaviourUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/BrushCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/BrushCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/ChangeLabel.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/ChangeLabel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/FloodFill.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/FloodFill.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/FloodFillController.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/FloodFillController.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/LabelBrushController.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/LabelBrushController.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/PlanarModeController.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/PlanarModeController.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/SelectLabelController.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/SelectLabelController.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/Ellipsoid.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/Ellipsoid.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/MappingCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/RealPoints.java
+++ b/src/main/java/sc/fiji/labkit/ui/brush/neighborhood/RealPoints.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/DatasetInputImage.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/DatasetInputImage.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/ImgPlusViewsOld.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/ImgPlusViewsOld.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/InputImage.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/InputImage.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataInputException.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataInputException.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataInputImage.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataInputImage.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataToImgPlus.java
+++ b/src/main/java/sc/fiji/labkit/ui/inputimage/SpimDataToImgPlus.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/labeling/Label.java
+++ b/src/main/java/sc/fiji/labkit/ui/labeling/Label.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/labeling/Labeling.java
+++ b/src/main/java/sc/fiji/labkit/ui/labeling/Labeling.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/labeling/LabelingSerializer.java
+++ b/src/main/java/sc/fiji/labkit/ui/labeling/LabelingSerializer.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/labeling/Labelings.java
+++ b/src/main/java/sc/fiji/labkit/ui/labeling/Labelings.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/labeling/LabelsLayer.java
+++ b/src/main/java/sc/fiji/labkit/ui/labeling/LabelsLayer.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/menu/MenuFactory.java
+++ b/src/main/java/sc/fiji/labkit/ui/menu/MenuFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/menu/MenuKey.java
+++ b/src/main/java/sc/fiji/labkit/ui/menu/MenuKey.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/CachedImageFactory.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/CachedImageFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/ColoredLabelsModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/ColoredLabelsModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/DefaultCachedImageFactory.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/DefaultCachedImageFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/DefaultHolder.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/DefaultHolder.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/DefaultSegmentationModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/DefaultSegmentationModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/ExtensionPoints.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/ExtensionPoints.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/Holder.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/Holder.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/ImageLabelingModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/ImageLabelingModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/LabelingModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/LabelingModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/MappedHolder.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/MappedHolder.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/SegmentationItem.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/SegmentationItem.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/SegmentationModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/SegmentationModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/SegmentationResultsModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/SegmentationResultsModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/SegmenterListModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/SegmenterListModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/TransformationModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/TransformationModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/models/WeakListeningHolder.java
+++ b/src/main/java/sc/fiji/labkit/ui/models/WeakListeningHolder.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/AddSegmenterPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/AddSegmenterPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/ComponentList.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/ComponentList.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/GuiUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/GuiUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/ImageInfoPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/ImageInfoPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/LabelPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/LabelPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/LabelToolsPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/LabelToolsPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/panel/SegmenterPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/panel/SegmenterPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/AbstractProcessFilesInDirectoryPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/AbstractProcessFilesInDirectoryPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitIJ1Plugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitIJ1Plugin.java
@@ -2,17 +2,17 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPlugin.java
@@ -2,17 +2,17 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/sc/fiji/labkit/ui/plugin/CziOpener.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/CziOpener.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/LabkitImportPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/LabkitImportPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/LabkitPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/LabkitPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/LabkitProbabilityMapForImagesInDirectoryPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/LabkitProbabilityMapForImagesInDirectoryPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/LabkitSegmentImagesInDirectoryPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/LabkitSegmentImagesInDirectoryPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/MeasureConnectedComponents.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/MeasureConnectedComponents.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/ResolutionPyramidSource.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/ResolutionPyramidSource.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitIJ1Plugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitIJ1Plugin.java
@@ -2,17 +2,17 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/plugin/ui/ImageSelectionDialog.java
+++ b/src/main/java/sc/fiji/labkit/ui/plugin/ui/ImageSelectionDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabeledImage.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabeledImage.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabeledImagesListPanel.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabeledImagesListPanel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectEditor.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectEditor.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectFileFilter.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectFileSerializer.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectFileSerializer.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectModel.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/LabkitProjectModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/project/NewProjectDialog.java
+++ b/src/main/java/sc/fiji/labkit/ui/project/NewProjectDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/ForwardingSegmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/ForwardingSegmenter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/PredictionLayer.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/PredictionLayer.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationPluginService.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationPluginService.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationTool.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationTool.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/SegmentationUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/Segmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/Segmenter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/TrainClassifier.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/TrainClassifier.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/weka/PixelClassificationPlugin.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/weka/PixelClassificationPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSettingsDialog.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSettingsDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/ARGBVector.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/ARGBVector.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/BdvUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/BdvUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/ColorSupplier.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/ColorSupplier.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/ConcurrentIntFunctionCache.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/ConcurrentIntFunctionCache.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/DimensionUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/DimensionUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/FileChooserCellEditor.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/FileChooserCellEditor.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/HDF5Saver.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/HDF5Saver.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/LabkitUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/LabkitUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/Notifier.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/Notifier.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/NumberAwareStringComparator.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/NumberAwareStringComparator.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/ParallelUtils.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/ParallelUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/ParametricNotifier.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/ParametricNotifier.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/progress/DummyProgressWriter.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/progress/DummyProgressWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/progress/PrintStreamToLines.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/progress/PrintStreamToLines.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/progress/ProgressDialog.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/progress/ProgressDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/progress/StatusServiceProgressWriter.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/progress/StatusServiceProgressWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/progress/SwingProgressWriter.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/progress/SwingProgressWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/IntervalIndexer2.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/IntervalIndexer2.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/MappingCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/ReadRetryWriteLock.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/ReadRetryWriteLock.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegion.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntType.java
+++ b/src/main/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntType.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/ChangingImageSegmentationComponentDemo.java
+++ b/src/test/java/demo/ChangingImageSegmentationComponentDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/CustomizedSegmentationComponentDemo.java
+++ b/src/test/java/demo/CustomizedSegmentationComponentDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/LabelingComponentDemo.java
+++ b/src/test/java/demo/LabelingComponentDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/LabelingComponentHdf5Demo.java
+++ b/src/test/java/demo/LabelingComponentHdf5Demo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/MultiChannelMovieDemo.java
+++ b/src/test/java/demo/MultiChannelMovieDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/ReplaceImageTest.java
+++ b/src/test/java/demo/ReplaceImageTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/SegmentationComponentDemo.java
+++ b/src/test/java/demo/SegmentationComponentDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/StartImageJAndLabkitDemo.java
+++ b/src/test/java/demo/StartImageJAndLabkitDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/custom_segmenter/CustomSegmenter.java
+++ b/src/test/java/demo/custom_segmenter/CustomSegmenter.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/custom_segmenter/CustomSegmenterDemo.java
+++ b/src/test/java/demo/custom_segmenter/CustomSegmenterDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/custom_segmenter/CustomSegmenterPlugin.java
+++ b/src/test/java/demo/custom_segmenter/CustomSegmenterPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/demo/custom_segmenter/MeanCalculator.java
+++ b/src/test/java/demo/custom_segmenter/MeanCalculator.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/GarbageCollectionTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/GarbageCollectionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/InitialLabelingTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/InitialLabelingTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/SegmentationUseCaseTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/SegmentationUseCaseTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/brush/FloodFillTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/brush/FloodFillTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/brush/neighborhood/EllipsoidTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/brush/neighborhood/EllipsoidTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/brush/neighborhood/RealPointsTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/brush/neighborhood/RealPointsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/imglib2/AffineTransform3DTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/imglib2/AffineTransform3DTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/inputimage/DatasetInputImageTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/inputimage/DatasetInputImageTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/inputimage/ImgPlusViewsOldTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/inputimage/ImgPlusViewsOldTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/inputimage/SpimDataToImgPlusTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/inputimage/SpimDataToImgPlusTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/labeling/LabelingSerializationTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/labeling/LabelingSerializationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/labeling/LabelingSlicerTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/labeling/LabelingSlicerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/labeling/LabelingTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/labeling/LabelingTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/labeling/SparseIterableRegionTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/labeling/SparseIterableRegionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/labeling/StartImageJ.java
+++ b/src/test/java/sc/fiji/labkit/ui/labeling/StartImageJ.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/models/CustomCachedImageFactoryDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/models/CustomCachedImageFactoryDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/models/DefaultSegmentationModelTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/models/DefaultSegmentationModelTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/models/ImageLabelingModelTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/models/ImageLabelingModelTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/multi_image/CreateLabkitProjectPlugin.java
+++ b/src/test/java/sc/fiji/labkit/ui/multi_image/CreateLabkitProjectPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/multi_image/LabkitProjectFrame.java
+++ b/src/test/java/sc/fiji/labkit/ui/multi_image/LabkitProjectFrame.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/multi_image/OpenLabkitProjectPlugin.java
+++ b/src/test/java/sc/fiji/labkit/ui/multi_image/OpenLabkitProjectPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/multi_image/ProjectSegmentationModel.java
+++ b/src/test/java/sc/fiji/labkit/ui/multi_image/ProjectSegmentationModel.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/panel/LabelPanelDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/panel/LabelPanelDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/panel/SegmenterPanelDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/panel/SegmenterPanelDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitIJ1PluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitIJ1PluginTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * The Labkit image segmentation tool for Fiji.
+ * %%
+ * Copyright (C) 2017 - 2024 Matthias Arzt
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package sc.fiji.labkit.ui.plugin;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/CalculateProbabilityMapWithLabkitPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/CziOpenerDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/CziOpenerDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/LabkitProbabilityMapForImagesInDirectoryPluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/LabkitProbabilityMapForImagesInDirectoryPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/LabkitSegmentImagesInDirectoryPluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/LabkitSegmentImagesInDirectoryPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/MeasureConnectedComponentsTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/MeasureConnectedComponentsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitIJ1PluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitIJ1PluginTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * The Labkit image segmentation tool for Fiji.
+ * %%
+ * Copyright (C) 2017 - 2024 Matthias Arzt
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package sc.fiji.labkit.ui.plugin;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitPluginTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/SegmentImageWithLabkitPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/plugin/SegmentRGBImageTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/plugin/SegmentRGBImageTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/progress/PrintStreamToLinesTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/progress/PrintStreamToLinesTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/progress/SwingProgressWriterDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/progress/SwingProgressWriterDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/project/LabeledImagesListPanelDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/project/LabeledImagesListPanelDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/project/LabkitProjectFileSerializerTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/project/LabkitProjectFileSerializerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/segmentation/SegmentationToolTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/segmentation/SegmentationToolTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenterTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenterTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/ConcurrentIntFunctionCacheTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/ConcurrentIntFunctionCacheTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/NotifierTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/NotifierTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/NumberAwareStringComparatorTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/NumberAwareStringComparatorTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/ParallelUtilsDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/ParallelUtilsDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/TestResources.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/TestResources.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * The Labkit image segmentation tool for Fiji.
+ * %%
+ * Copyright (C) 2017 - 2024 Matthias Arzt
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package sc.fiji.labkit.ui.utils;
 
 import sc.fiji.labkit.ui.plugin.SegmentImageWithLabkitPluginTest;

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/FlightRecord.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/FlightRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/HDF5SaverDemo.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/HDF5SaverDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/HDF5SaverTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/HDF5SaverTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/ReadRetryWriteLockTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/ReadRetryWriteLockTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegionTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseIterableRegionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeBenchmark.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeBenchmark.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeBenchmark2.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeBenchmark2.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/SparseRandomAccessIntTypeTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/sc/fiji/labkit/ui/utils/sparse/ThreadSafeLongIntHasMapTest.java
+++ b/src/test/java/sc/fiji/labkit/ui/utils/sparse/ThreadSafeLongIntHasMapTest.java
@@ -2,7 +2,7 @@
  * #%L
  * The Labkit image segmentation tool for Fiji.
  * %%
- * Copyright (C) 2017 - 2023 Matthias Arzt
+ * Copyright (C) 2017 - 2024 Matthias Arzt
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/resources/export.xml
+++ b/src/test/resources/export.xml
@@ -3,7 +3,7 @@
   #%L
   The Labkit image segmentation tool for Fiji.
   %%
-  Copyright (C) 2017 - 2023 Matthias Arzt
+  Copyright (C) 2017 - 2024 Matthias Arzt
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/test/resources/multi-angle-dataset.xml
+++ b/src/test/resources/multi-angle-dataset.xml
@@ -3,7 +3,7 @@
   #%L
   The Labkit image segmentation tool for Fiji.
   %%
-  Copyright (C) 2017 - 2023 Matthias Arzt
+  Copyright (C) 2017 - 2024 Matthias Arzt
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/test/resources/size-mismatch-dataset.xml
+++ b/src/test/resources/size-mismatch-dataset.xml
@@ -3,7 +3,7 @@
   #%L
   The Labkit image segmentation tool for Fiji.
   %%
-  Copyright (C) 2017 - 2023 Matthias Arzt
+  Copyright (C) 2017 - 2024 Matthias Arzt
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This avoids downstream issues with the too-late patching of net.imagej:ij that can occur in some scenarios when imagej-legacy is on the classpath.
