### PR TITLE
New method getSegmenter()

### DIFF
--- a/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenter.java
+++ b/src/main/java/sc/fiji/labkit/ui/segmentation/weka/TrainableSegmentationSegmenter.java
@@ -348,6 +348,10 @@ public class TrainableSegmentationSegmenter implements Segmenter {
 		featureSettings = segmenter.features().settings();
 	}
 
+	public sc.fiji.labkit.pixel_classification.classification.Segmenter getSegmenter() {
+		return segmenter;
+	}
+
 	@Override
 	public int[] suggestCellSize(ImgPlus<?> image) {
 		if (ImgPlusViewsOld.hasAxis(image, Axes.CHANNEL))


### PR DESCRIPTION
So that one can, on a script, getSegmenter().getClassifier(), to then e.g., call setNumThreads(1) on the underlying FastRandomForest instance. At the moment there's no way to set the number of threads used to 1 except via Prefs.setThreads(1), which is fragile.